### PR TITLE
Implement web crawler using GitHub models

### DIFF
--- a/.github/models/extract.prompt.yaml
+++ b/.github/models/extract.prompt.yaml
@@ -1,6 +1,6 @@
 ﻿name: Extract summary and keywords
 description: Summarize municipal bulletin articles and extract keywords
-model: phi4
+model: phi-4-reasoning
 modelParameters:
   temperature: 0.2
   maxTokens: 256

--- a/.github/models/summary.prompt.yaml
+++ b/.github/models/summary.prompt.yaml
@@ -1,0 +1,18 @@
+name: Summarize web page
+description: Summarize web page text and extract keywords
+model: phi-4-reasoning
+modelParameters:
+  temperature: 0.2
+  maxTokens: 256
+messages:
+  - role: system
+    content: |
+      あなたはウェブページの内容を要約し、重要なキーワードを抽出するアシスタントです。
+      与えられたテキストを読み、短い一文で要約し、キーワードを5個以内で返してください。
+      出力は次のJSON形式で返します。
+      {
+        "summary": "要約",
+        "keywords": ["keyword1", "keyword2", "..."]
+      }
+  - role: user
+    content: "{{text}}"

--- a/README-en.md
+++ b/README-en.md
@@ -8,11 +8,11 @@ The contents of the `docs/` folder are published via GitHub Pages. You can acces
 
 [Bulletin Search Page](https://mitsuo-koikawa.github.io/Municipal-Bulletin)
 
-An [advanced search page](https://mitsuo-koikawa.github.io/Municipal-Bulletin/advanced.html) is also available. It requires GitHub authentication and is limited to repository collaborators. Text you provide is analyzed with GitHub Models **Phi4** to find related articles. Access logs are kept on GitHub storage for 30 days.
+An [advanced search page](https://mitsuo-koikawa.github.io/Municipal-Bulletin/advanced.html) is also available. It requires GitHub authentication and is limited to repository collaborators. Text you provide is analyzed with GitHub Models **phi-4-reasoning** to find related articles. Access logs are kept on GitHub storage for 30 days.
 
 ## Updating the Index
 
-CSV files are not automatically indexed. Previously, `.github/workflows/update-index.yml` ran automatically, but to reduce token usage for GitHub Models **Phi4**, indexing is now performed manually. Use `scripts/update_index.py` to generate the index; if it fails, a simplified fallback will be used.
+CSV files are not automatically indexed. Previously, `.github/workflows/update-index.yml` ran automatically, but to reduce token usage for GitHub Models, indexing is now performed manually. Use `scripts/update_index.py` to generate the index; if it fails, a simplified fallback will be used.
 
 ### Manual Execution
 
@@ -22,6 +22,10 @@ python scripts/update_index.py
 ```
 
 Commit the generated `docs/index.json` file.
+
+## Web Crawl Summary
+
+Run `scripts/crawl_sites.py` to fetch recent information from predefined web sites and summarize the pages with GitHub Models. The results are written to `docs/crawl_index.json` and can be searched via the MCP server.
 
 ## CSV Encoding Check
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ English version available: [README-en.md](README-en.md)
 
 [広報誌検索ページ](https://mitsuo-koikawa.github.io/Municipal-Bulletin)
 
-GitHub アカウントで認証して利用する [高度な検索ページ](https://mitsuo-koikawa.github.io/Municipal-Bulletin/advanced.html) も用意しました。こちらでは入力した文章を GitHub Models の **Phi4** で解析し、インデックスから関連する記事を検索します。検索時のアクセスログは GitHub 上のストレージに30日間保存されます。リポジトリ Collaborator のみ利用可能です。
+GitHub アカウントで認証して利用する [高度な検索ページ](https://mitsuo-koikawa.github.io/Municipal-Bulletin/advanced.html) も用意しました。こちらでは入力した文章を GitHub Models の **phi-4-reasoning** で解析し、インデックスから関連する記事を検索します。検索時のアクセスログは GitHub 上のストレージに30日間保存されます。リポジトリ Collaborator のみ利用可能です。
 
 ## インデックスの更新
 
-CSV ファイルが追加・変更されても自動では更新されません。以前は `.github/workflows/update-index.yml` が自動実行されていましたが、GitHub Models の SLM **Phi4** を利用する際のトークン消費を抑えるため現在は手動実行としています。インデックスの生成には `scripts/update_index.py` を使用し、失敗した場合は簡易的な処理で代替します。
+CSV ファイルが追加・変更されても自動では更新されません。以前は `.github/workflows/update-index.yml` が自動実行されていましたが、GitHub Models の SLM を利用する際のトークン消費を抑えるため現在は手動実行としています。インデックスの生成には `scripts/update_index.py` を使用し、失敗した場合は簡易的な処理で代替します。
 
 ### 手動で実行する場合
 
@@ -24,6 +24,10 @@ python scripts/update_index.py
 ```
 
 生成された `docs/index.json` をコミットしてください。
+
+## Web クロール要約
+
+`scripts/crawl_sites.py` を実行すると、あらかじめ設定したウェブサイトから情報を取得し、GitHub Models を用いて要約した結果を `docs/crawl_index.json` に保存します。このファイルは MCP サーバー経由で検索できます。
 
 ## CSV 文字コードの検証
 

--- a/docs/crawl_index.json
+++ b/docs/crawl_index.json
@@ -1,0 +1,9 @@
+[
+  {
+    "title": "Sample Entry",
+    "url": "https://example.com",
+    "summary": "Sample summary",
+    "keywords": ["sample"],
+    "timestamp": "2024-01-01T00:00:00Z"
+  }
+]

--- a/mcp_server/advsearch/__init__.py
+++ b/mcp_server/advsearch/__init__.py
@@ -28,7 +28,7 @@ def github_user(token: str):
         return r.json()
     return None
 
-def run_phi4(text: str):
+def run_slm(text: str):
     token = os.getenv('GH_MODELS_TOKEN')
     if not token:
         return []
@@ -48,7 +48,7 @@ def run_phi4(text: str):
                 tags = [t.strip() for t in re.split(r'[、,\s]+', tags) if t.strip()]
             return tags
     except Exception as e:
-        print('phi4 error', e)
+        print('slm error', e)
     return []
 
 def expand_groups(words):
@@ -67,7 +67,7 @@ def entry_matches(entry, groups):
     return all(includes_any(text, g) for g in groups)
 
 def search_entries(entries, q):
-    words = run_phi4(q.strip())
+    words = run_slm(q.strip())
     if not words:
         return []
     groups = expand_groups(words)

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,3 +1,4 @@
 azure-functions
 pandas
 requests
+beautifulsoup4

--- a/mcp_server/websearch/__init__.py
+++ b/mcp_server/websearch/__init__.py
@@ -1,0 +1,49 @@
+import json
+import os
+import azure.functions as func
+from typing import Any, List
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+INDEX_PATH = os.path.join(BASE_DIR, 'docs', 'crawl_index.json')
+
+try:
+    with open(INDEX_PATH, 'r', encoding='utf-8') as f:
+        INDEX = json.load(f)
+except Exception:
+    INDEX = []
+
+
+def validate_query(q: Any) -> str | None:
+    if not isinstance(q, str):
+        return None
+    q = q.strip()
+    return q if q else None
+
+
+def search_entries(entries: List[dict], q: str) -> List[dict]:
+    words = [w for w in q.lower().split() if w]
+    results = []
+    for e in entries:
+        text = ' '.join([
+            e.get('title', ''),
+            e.get('summary', ''),
+            ' '.join(e.get('keywords', []))
+        ]).lower()
+        if all(w in text for w in words):
+            results.append(e)
+    return results
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    q = req.params.get('q')
+    if not q and req.get_body():
+        try:
+            q = req.get_json().get('q')
+        except Exception:
+            q = None
+    q = validate_query(q)
+    if not q:
+        return func.HttpResponse('Invalid or missing query', status_code=400)
+    results = search_entries(INDEX, q)
+    body = json.dumps(results[:20], ensure_ascii=False)
+    return func.HttpResponse(body, mimetype='application/json')

--- a/mcp_server/websearch/function.json
+++ b/mcp_server/websearch/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "post"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas
 chardet
+requests
+beautifulsoup4

--- a/scripts/crawl_sites.py
+++ b/scripts/crawl_sites.py
@@ -1,0 +1,78 @@
+import os
+import json
+import requests
+import subprocess
+import re
+import datetime
+from bs4 import BeautifulSoup
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+OUTPUT = os.path.join(BASE_DIR, 'docs', 'crawl_index.json')
+PROMPT_PATH = os.path.join(BASE_DIR, '.github', 'models', 'summary.prompt.yaml')
+
+SITES = [
+    'https://github.blog'
+]
+
+
+def fetch_text(url: str) -> tuple[str, str]:
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    html = resp.text
+    soup = BeautifulSoup(html, 'html.parser')
+    title = soup.title.string.strip() if soup.title else url
+    paragraphs = ' '.join(p.get_text(separator=' ', strip=True) for p in soup.find_all('p'))
+    return title, paragraphs
+
+
+def run_slm(text: str) -> tuple[str, list[str]]:
+    env = os.environ.copy()
+    token = os.getenv('GH_MODELS_TOKEN')
+    if token:
+        env['GH_TOKEN'] = token
+    try:
+        res = subprocess.run([
+            'gh', 'models', 'run', PROMPT_PATH,
+            '--var', f'text={text}'
+        ], check=True, capture_output=True, text=True, env=env)
+        out = res.stdout.strip()
+        m = re.search(r'{.*}', out, re.DOTALL)
+        if m:
+            data = json.loads(m.group(0))
+            summary = data.get('summary', '').strip()
+            keywords = data.get('keywords') or data.get('tags') or []
+            if isinstance(keywords, str):
+                keywords = [t.strip() for t in re.split(r'[、,\s]+', keywords) if t.strip()]
+            return summary, keywords
+    except Exception as e:
+        print('slm error', e)
+    return '', []
+
+
+def crawl_site(url: str) -> dict:
+    title, text = fetch_text(url)
+    summary, keywords = run_slm(text)
+    return {
+        'title': title,
+        'url': url,
+        'summary': summary,
+        'keywords': keywords,
+        'timestamp': datetime.datetime.utcnow().isoformat() + 'Z'
+    }
+
+
+def main():
+    entries = []
+    for url in SITES:
+        try:
+            entries.append(crawl_site(url))
+        except Exception as e:
+            print('crawl error', url, e)
+    os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
+    with open(OUTPUT, 'w', encoding='utf-8') as f:
+        json.dump(entries, f, ensure_ascii=False, indent=2)
+    print(f'Wrote {len(entries)} entries to {OUTPUT}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/update_index.py
+++ b/scripts/update_index.py
@@ -28,7 +28,7 @@ def fallback_tags(text: str) -> List[str]:
     return seen
 
 
-def run_phi4(text: str) -> Tuple[str, List[str]]:
+def run_slm(text: str) -> Tuple[str, List[str]]:
     text = text.strip().replace('\n', ' ')
     if not text:
         return "", []
@@ -52,7 +52,7 @@ def run_phi4(text: str) -> Tuple[str, List[str]]:
 
 
 def extract_summary_and_tags(text: str) -> Tuple[str, List[str]]:
-    summary, tags = run_phi4(text)
+    summary, tags = run_slm(text)
     if summary or tags:
         return summary, tags
     return fallback_summary(text), fallback_tags(text)


### PR DESCRIPTION
## Summary
- switch municipal bulletin summarization to GitHub Models **phi2**
- add prompt for summarizing web pages
- implement `scripts/crawl_sites.py` to collect and summarize pages
- include a sample `docs/crawl_index.json`
- support new data via `mcp_server/websearch` Azure Function
- update docs and requirements
- **switch prompts from phi2 to phi-4-reasoning**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870fee400b08320b61bfb17543e5a38